### PR TITLE
update HHS footer link

### DIFF
--- a/src/layouts/default.js
+++ b/src/layouts/default.js
@@ -139,7 +139,7 @@ export const DefaultLayout = ({ children }) => {
                       primary={
                         <Link
                           lightIcon
-                          to="https://hhs.responsibledisclosure.com/hc/en-us"
+                          to="https://www.hhs.gov/vulnerability-disclosure-policy/index.html"
                         >
                           HHS Vulnerability Disclosure
                         </Link>


### PR DESCRIPTION
the correct link out for the Vulnerability footer link is https://www.hhs.gov/vulnerability-disclosure-policy/index.html 