### PR TITLE
Update/google analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -129,27 +129,6 @@ module.exports = {
         icon: `src/images/favicon.png`, // This path is relative to the root of the site.
       },
     },
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: "UA-120639061-2", // The property ID; the tracking code won't be generated without it
-        head: true, // Defines where to place the tracking script - `true` in the head and `false` in the body
-        anonymize: true, // Setting this parameter is optional
-        respectDNT: true, // Setting this parameter is also optional
-        // exclude: ["/preview/**", "/do-not-track/me/too/"], // Avoids sending pageview hits from custom paths
-        // pageTransitionDelay: 0, // Delays sending pageview hits on route update (in milliseconds)
-        // optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID", // Enables Google Optimize using your container Id
-        // experimentId: "YOUR_GOOGLE_EXPERIMENT_ID", // Enables Google Optimize Experiment ID
-        // variationId: "YOUR_GOOGLE_OPTIMIZE_VARIATION_ID", // Set Variation ID. 0 for original 1,2,3....
-        // Any additional optional fields
-        // Documented
-        //  here: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#create
-        // and here: https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/
-        // sampleRate: 5, // Specifies what percentage of users should be tracked. This defaults to 100 (no users are sampled out) but large sites may need to use a lower sample rate to stay within Google Analytics processing limits.
-        siteSpeedSampleRate: 10, // This setting determines how often site speed beacons will be sent. By default, 1% of users will be automatically be tracked.
-        cookieDomain: "biodatacatalyst.nhlbi.nih.gov", // Specifies the domain used to store the analytics cookie. Setting this to 'none' sets the cookie without specifying a domain.
-      },
-    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -129,6 +129,12 @@ module.exports = {
         icon: `src/images/favicon.png`, // This path is relative to the root of the site.
       },
     },
+    {
+      resolve: `gatsby-plugin-google-gtag`,
+      options: {
+        trackingIds: ["G-2M4JYYSBD3"],
+      },
+    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby": "^2.26.1",
     "gatsby-image": "^2.2.30",
     "gatsby-plugin-anchor-links": "^1.1.1",
-    "gatsby-plugin-google-analytics": "^2.1.35",
+    "gatsby-plugin-google-gtag": "^4.24.0",
     "gatsby-plugin-manifest": "^2.6.1",
     "gatsby-plugin-offline": "^3.0.17",
     "gatsby-plugin-react-helmet": "^3.2.2",


### PR DESCRIPTION
Actions summary:
- switched out gatsby plugin packages to updated gtag package (old: `gatsby-plugin-google-analytics`, new: `gatsby-plugin-google-gtag`)
- updated measurement ID with new ID created for GA4 property
- ran the build locally and checked that the request is sending properly
- also checked the google analytics UI since this measurement ID was created a while ago, and the user data does come through when the application is built locally

@mbwatson in this update, I removed the options (formerly `lines 135-150`) and I am wondering if these options need to be added back in with the new package `gatsby-plugin-google-gtag`.