### PR TITLE
update bdc video link on staging

### DIFF
--- a/src/pages/resources/learn.js
+++ b/src/pages/resources/learn.js
@@ -68,6 +68,10 @@ const resources = [
         url: "https://videocast.nih.gov/watch=37703"
       },
       {
+        text: "BioData Catalyst Videos",
+        url: "https://www.youtube.com/channel/UCGkmY5oNK8uFZzT8vV_9KgQ"
+      },
+      {
         text: "Dockstore Videos",
         url: "https://www.youtube.com/channel/UCFWNYqxQvVLAuZq8rdOSE4g/videos"
       },


### PR DESCRIPTION
The purpose of this PR is to manually update staging to mirror the content changes on the master branch, where the BioData Catalyst Youtube Channel is added to the Video section of the Resources > Learn page.