### PR TITLE
Update/add-sortable-toggle-on-studies-tables

### DIFF
--- a/src/data/studies/covid-studies-columns.json
+++ b/src/data/studies/covid-studies-columns.json
@@ -10,7 +10,7 @@
   {
     "name": "Consent",
     "selector": "Consent_Code",
-    "type": "array",
+    "type": "string",
     "omit": false,
     "groupable": false,
     "sortable": true,

--- a/src/data/studies/covid-studies-columns.json
+++ b/src/data/studies/covid-studies-columns.json
@@ -4,6 +4,7 @@
     "selector": "Accession",
     "type": "string",
     "omit": false,
+    "sortable": true,
     "groupable": false,
     "grow": 1
   },

--- a/src/data/studies/studies-columns.json
+++ b/src/data/studies/studies-columns.json
@@ -4,6 +4,7 @@
     "selector": "Accession",
     "type": "string",
     "omit": false,
+    "sortable": true,
     "groupable": false,
     "grow": 1
   },


### PR DESCRIPTION
For whatever reason I can't recreate that gql error I had before. If someone else could pull and verify it's working, that'd be great.

*I also switched the `Consent_Code` type from `array` to `string`. I don't think it actually does anything, but makes more sense*