### PR TITLE
honeypot: switch input to ref

### DIFF
--- a/src/components/form/cloud-credits.js
+++ b/src/components/form/cloud-credits.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import { Paragraph } from "../typography";
@@ -59,7 +59,7 @@ const ErrorMessage = () => {
 };
 
 export const CloudCreditsForm = (props) => {
-  const [fakeField, setFakeField] = useState("");
+  const honeypotFieldRef = useRef(null);
   const [name, setName] = useState("");
   const [username, setUserName] = useState("");
   const [terraUsername, setTerraUserName] = useState("");
@@ -121,7 +121,7 @@ export const CloudCreditsForm = (props) => {
   const handleSubmit = (event) => {
     event.preventDefault();
 
-    if(fakeField !== "") return;
+    if(honeypotFieldRef.current?.value !== "") return;
 
     let prefix = testSubmission ? "[TEST] " : "";
     const description =
@@ -389,7 +389,6 @@ export const CloudCreditsForm = (props) => {
     }
   };
 
-  const handleChangeFakeField = (event) => setFakeField(event.target.value);
   const handleChangeName = (event) => setName(event.target.value);
   const handleChangeProjectPi = (event) => setProjectPi(event.target.value);
   const handleChangeUserName = (event) => setUserName(event.target.value);
@@ -457,8 +456,10 @@ export const CloudCreditsForm = (props) => {
               type="text"
               id="website"
               name="website"
-              value={fakeField}
-              onChange={handleChangeFakeField}
+              defaultValue=""
+              tabIndex="-1"
+              autoComplete="off"
+              ref={honeypotFieldRef}
             />
           </FormControl>
           <FormControl>

--- a/src/components/form/ecosystem.js
+++ b/src/components/form/ecosystem.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useRef, useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import { Paragraph } from "../typography";
@@ -51,7 +51,7 @@ const ErrorMessage = () => {
 };
 
 export const EcoSystemForm = (props) => {
-  const [fakeField, setFakeField] = useState("");
+  const honeypotFieldRef = useRef(null);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [commons, setCommons] = useState("");
@@ -66,7 +66,7 @@ export const EcoSystemForm = (props) => {
   const handleSubmit = (event) => {
     event.preventDefault();
 
-    if(fakeField !== "") return;
+    if(honeypotFieldRef.current?.value !== "") return;
     
     const payload = {
       name: name,
@@ -100,7 +100,6 @@ export const EcoSystemForm = (props) => {
     submitContact();
   };
 
-  const handleChangeFakeField = (event) => setFakeField(event.target.value);
   const handleChangeName = (event) => setName(event.target.value);
   const handleChangeCommons = (event) => setCommons(event.target.value);
   const handleChangeEmail = (event) => setEmail(event.target.value);
@@ -134,8 +133,10 @@ export const EcoSystemForm = (props) => {
                 type="text"
                 id="website"
                 name="website"
-                value={fakeField}
-                onChange={handleChangeFakeField}
+                defaultValue=""
+                tabIndex="-1"
+                autoComplete="off"
+                ref={honeypotFieldRef}
               />
             </FormControl>
             <FormControl>


### PR DESCRIPTION
No longer uses React state, which is completely ineffective for bots setting the `value` attr directly. Also added `autocomplete="off"` attribute to the hidden fields, to prevent browser autofill. These tags may tip off a bot that this field is a honeypot, but it's better than blocking a real user.