### PR TITLE
Prototype/news page

### DIFF
--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -3,3 +3,4 @@ export * from "./card-header";
 export * from "./card-body";
 export * from "./card-footer";
 export * from "./resource-card";
+export * from "./news-card"

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -21,16 +21,9 @@ const NewsCardLink = styled(Link)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-`
-
-const NewsCardWrapper = styled.div`
-  overflow: hidden;
-  margin-bottom: 3rem;
-  height: 100%;
   padding: 1.5rem 2rem;
-
-  background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
 `
+
 //add a filter on it to change the color
 
 const NewsCardHeading = styled.h2`
@@ -49,7 +42,6 @@ const NewsCardHeading = styled.h2`
 
 export const NewsCard = ({ newsItem }) => {
   return (
-    <NewsCardWrapper>
     <NewsCardLink to={newsItem.newsLink} noIcon>
 
       <div>
@@ -74,6 +66,5 @@ export const NewsCard = ({ newsItem }) => {
       </div>
 
     </NewsCardLink>
-    </NewsCardWrapper>
   );
 };

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -14,9 +14,12 @@ const NewsCardLink = styled(Link)`
   margin-bottom: 3rem;
   height: 100%;
   background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
-  transition: transform 200ms ease-out;
+  transition: transform 300ms ease-out;
+  filter: drop-shadow(6px 6px 4px var(--color-lightgrey));
+  transition: filter 300ms ease-in;
   &:hover, &:focus {
-    transform: scale(1.05);
+    transform: scale(1.015);
+    filter: drop-shadow(12px 12px 6px var(--color-lightgrey));
   };
   display: flex;
   flex-direction: column;

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -15,21 +15,22 @@ const NewsCardWrapper = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, #21568a 0%, #314f6e 100%);
+  background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
   justify-content: space-between;
-  transition: background-color 200ms ease-out;
-  &:hover, &:focus-within {
-    background-color: rgba(33, 86, 138, 0.7);
+  transition: transform 200ms ease-out;
+  &:hover, &:focus {
+    transform: scale(1.01);
     color: rgba(255, 255,255, 0.7)
   }
 `
+//add a filter on it to change the color
 
 const NewsCardHeading = styled.h2`
   line-height: 1.5; 
   letter-spacing: 0.5px;
   text-decoration: none;
-  font-weight: '400';
-  font-size: '100%';
+  font-weight: 500;
+  font-size: 150%;
   color: #fff;
   &:hover, &:focus {
     text-decoration: none;
@@ -41,13 +42,19 @@ const NewsCardHeading = styled.h2`
 export const NewsCard = ({ newsItem }) => {
   return (
     <NewsCardWrapper >
+      <div>
         <NewsCardHeading >
           {newsItem.newsTitle}
         </NewsCardHeading>
+        <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
+          {newsItem.newsDate}
+        </Paragraph>
+
+      </div>
 
       <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
         <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
-          {newsItem.newsDate}
+          {newsItem.newsSource}
         </Paragraph>
         <ExternalLinkIcon
           fill={"#eee"}

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -3,25 +3,33 @@ import { Card, CardHeader, CardBody } from ".";
 import { Heading, Paragraph } from "../../components/typography";
 import styled from "styled-components";
 import { ExternalLinkIcon } from "../icons";
-
+import { Link } from "../../components/link"
 //add animation to make card grow slightly on hover
 //include onFocus state too
-const NewsCardWrapper = styled.div`
+
+//make newscard warpper a styled Link?
+
+const NewsCardLink = styled(Link)`
   overflow: hidden;
-  ${props =>
-    props.metaAlert ? `box-shadow: 0 0 8px 4px rgba(186, 194, 204, 0.5);` : `box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.25);`}
   margin-bottom: 3rem;
-  padding: 1.5rem 2rem;
   height: 100%;
-  display: flex;
-  flex-direction: column;
   background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
-  justify-content: space-between;
   transition: transform 200ms ease-out;
   &:hover, &:focus {
-    transform: scale(1.01);
-    color: rgba(255, 255,255, 0.7)
-  }
+    transform: scale(1.05);
+  };
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`
+
+const NewsCardWrapper = styled.div`
+  overflow: hidden;
+  margin-bottom: 3rem;
+  height: 100%;
+  padding: 1.5rem 2rem;
+
+  background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
 `
 //add a filter on it to change the color
 
@@ -41,7 +49,9 @@ const NewsCardHeading = styled.h2`
 
 export const NewsCard = ({ newsItem }) => {
   return (
-    <NewsCardWrapper >
+    <NewsCardWrapper>
+    <NewsCardLink to={newsItem.newsLink} noIcon>
+
       <div>
         <NewsCardHeading >
           {newsItem.newsTitle}
@@ -56,13 +66,14 @@ export const NewsCard = ({ newsItem }) => {
         <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
           {newsItem.newsSource}
         </Paragraph>
-        <ExternalLinkIcon
-          fill={"#eee"}
+        {/* <ExternalLinkIcon
+          fill={"#555"}
           size={14}
           style={{ marginLeft: "0.25rem" }}
-        />
+        /> */}
       </div>
 
+    </NewsCardLink>
     </NewsCardWrapper>
   );
 };

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { Card, CardHeader, CardBody } from ".";
+import { Heading, Paragraph } from "../../components/typography";
+import styled from "styled-components";
+import { ExternalLinkIcon } from "../icons";
+
+//add animation to make card grow slightly on hover
+//include onFocus state too
+const NewsCardWrapper = styled.div`
+  overflow: hidden;
+  ${props =>
+    props.metaAlert ? `box-shadow: 0 0 8px 4px rgba(186, 194, 204, 0.5);` : `box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.25);`}
+  margin-bottom: 3rem;
+  padding: 1.5rem 2rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #21568a 0%, #314f6e 100%);
+  justify-content: space-between;
+  transition: background-color 200ms ease-out;
+  &:hover, &:focus-within {
+    background-color: rgba(33, 86, 138, 0.7);
+    color: rgba(255, 255,255, 0.7)
+  }
+`
+
+const NewsCardHeading = styled.h2`
+  line-height: 1.5; 
+  letter-spacing: 0.5px;
+  text-decoration: none;
+  font-weight: '400';
+  font-size: '100%';
+  color: #fff;
+  &:hover, &:focus {
+    text-decoration: none;
+  }
+
+`
+
+
+export const NewsCard = ({ newsItem }) => {
+  return (
+    <NewsCardWrapper >
+        <NewsCardHeading >
+          {newsItem.newsTitle}
+        </NewsCardHeading>
+
+      <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+        <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
+          {newsItem.newsDate}
+        </Paragraph>
+        <ExternalLinkIcon
+          fill={"#eee"}
+          size={14}
+          style={{ marginLeft: "0.25rem" }}
+        />
+      </div>
+
+    </NewsCardWrapper>
+  );
+};

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -54,15 +54,21 @@ export const NewsCard = ({ newsItem }) => {
 
       </div>
 
-      <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+      <div style={{display: "block"}}>
         <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
           {newsItem.newsSource}
         </Paragraph>
-        {/* <ExternalLinkIcon
-          fill={"#555"}
-          size={14}
-          style={{ marginLeft: "0.25rem" }}
-        /> */}
+        { newsItem.external &&
+          (
+            <div style={{textAlign: "right"}}>
+              <ExternalLinkIcon
+                fill={"#fff"}
+                size={14}
+                style={{ marginLeft: "0.25rem" }}
+              />
+            </div>
+          )
+        }
       </div>
 
     </NewsCardLink>

--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -14,12 +14,12 @@ const NewsCardLink = styled(Link)`
   margin-bottom: 3rem;
   height: 100%;
   background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
-  transition: transform 300ms ease-out;
+  transition: transform 700ms;
   filter: drop-shadow(6px 6px 4px var(--color-lightgrey));
-  transition: filter 300ms ease-in;
+  transition: filter 100ms ease-in;
   &:hover, &:focus {
-    transform: scale(1.015);
-    filter: drop-shadow(12px 12px 6px var(--color-lightgrey));
+    transform: translateY(-1.5px);
+    filter: drop-shadow(10px 10px 6px var(--color-lightgrey));
   };
   display: flex;
   flex-direction: column;

--- a/src/components/link/external-link.js
+++ b/src/components/link/external-link.js
@@ -9,6 +9,7 @@ export const ExternalLink = ({
   noIcon,
   lightIcon,
   children,
+  className,
   ...props
 }) => {
   const dialog = useDialog();
@@ -55,7 +56,7 @@ export const ExternalLink = ({
   };
 
   return requiresConfirmation ? (
-    <a href={to} onClick={triggerDialog} className={asButton && 'button-link' }>
+    <a href={to} onClick={triggerDialog} className={`${className} ${asButton && 'button-link'}`}>
       {children}
       {!noIcon && (
         <ExternalLinkIcon
@@ -67,7 +68,7 @@ export const ExternalLink = ({
       )}
     </a>
   ) : (
-    <a href={to} className={asButton && 'button-link'} target="_blank" rel="noopener noreferrer" {...props}>
+    <a href={to} className={`${className} ${asButton && 'button-link'}`} target="_blank" rel="noopener noreferrer" {...props}>
       {children}
     </a>
   );

--- a/src/components/link/external-link.js
+++ b/src/components/link/external-link.js
@@ -55,7 +55,7 @@ export const ExternalLink = ({
   };
 
   return requiresConfirmation ? (
-    <a href={to} onClick={triggerDialog} className={asButton ? 'button-link' : null}>
+    <a href={to} onClick={triggerDialog} className={asButton && 'button-link' }>
       {children}
       {!noIcon && (
         <ExternalLinkIcon
@@ -67,7 +67,7 @@ export const ExternalLink = ({
       )}
     </a>
   ) : (
-    <a href={to} className={asButton ? 'button-link' : null} target="_blank" rel="noopener noreferrer" {...props}>
+    <a href={to} className={asButton && 'button-link'} target="_blank" rel="noopener noreferrer" {...props}>
       {children}
     </a>
   );

--- a/src/data/menu.js
+++ b/src/data/menu.js
@@ -8,12 +8,16 @@ export const menuItems = [
         path: "/about/overview",
       },
       {
+        text: "Events",
+        path: "/about/events",
+      },
+      {
         text: "Latest Updates",
         path: "/about/latest-updates",
       },
       {
-        text: "Events",
-        path: "/about/events",
+        text: "News Coverage",
+        path: "/about/news",
       },
       {
         text: "Published Research",

--- a/src/data/newsCoverage.json
+++ b/src/data/newsCoverage.json
@@ -1,32 +1,38 @@
 [
   {
-    "newsTitle": "A Cloud-Based Data Democratization Tool, RTI International",
+    "newsTitle": "A Cloud-Based Data Democratization Tool",
     "newsLink": "https://www.rti.org/impact/data-democratization-tool",
-    "newsDate": "March 15, 2023"
+    "newsDate": "March 15, 2023",
+    "newsSource": "RTI International"
   },
   {
     "newsTitle": "Accelerating heart failure research, NHLBI NIH",
     "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
-    "newsDate": "December 14, 2022"
+    "newsDate": "December 14, 2022",
+    "newsSource": "NHLBI NIH"
+  },
+  {
+    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast",
+    "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
+    "newsDate": "January 25, 2022",
+    "newsSource": "GovCIO Media & Research"
   },
   {
     "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast (GovCIO Media & Research)",
     "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
-    "newsDate": "January 25, 2022"
-  },
-  {
-    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast (GovCIO Media & Research)",
-    "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
-    "newsDate": "January 25, 2022"
+    "newsDate": "January 25, 2022",
+    "newsSource": "GovCIO Media & Research"
   },
   {
     "newsTitle": "A Cloud-Based Data Democratization Tool, RTI International",
     "newsLink": "https://www.rti.org/impact/data-democratization-tool",
-    "newsDate": "March 15, 2023"
+    "newsDate": "March 15, 2023",
+    "newsSource": "RTI International"
   },
   {
     "newsTitle": "Accelerating heart failure research, NHLBI NIH",
     "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
-    "newsDate": "December 14, 2022"
+    "newsDate": "December 14, 2022",
+    "newsSource": "NHLBI NIH"
   }
 ]

--- a/src/data/newsCoverage.json
+++ b/src/data/newsCoverage.json
@@ -3,18 +3,21 @@
     "newsTitle": "A Cloud-Based Data Democratization Tool",
     "newsLink": "https://www.rti.org/impact/data-democratization-tool",
     "newsDate": "",
-    "newsSource": "RTI International"
+    "newsSource": "RTI International",
+    "external": true
   },
   {
     "newsTitle": "Accelerating heart failure research",
     "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
     "newsDate": "December 14, 2022",
-    "newsSource": "NHLBI NIH"
+    "newsSource": "NHLBI NIH",
+    "external": false
   },
   {
     "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research",
     "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
     "newsDate": "January 25, 2022",
-    "newsSource": "HealthCast Podcast, GovCIO Media & Research"
+    "newsSource": "HealthCast Podcast, GovCIO Media & Research",
+    "external": true
   }
 ]

--- a/src/data/newsCoverage.json
+++ b/src/data/newsCoverage.json
@@ -2,37 +2,19 @@
   {
     "newsTitle": "A Cloud-Based Data Democratization Tool",
     "newsLink": "https://www.rti.org/impact/data-democratization-tool",
-    "newsDate": "March 15, 2023",
+    "newsDate": "",
     "newsSource": "RTI International"
   },
   {
-    "newsTitle": "Accelerating heart failure research, NHLBI NIH",
+    "newsTitle": "Accelerating heart failure research",
     "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
     "newsDate": "December 14, 2022",
     "newsSource": "NHLBI NIH"
   },
   {
-    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast",
+    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research",
     "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
     "newsDate": "January 25, 2022",
-    "newsSource": "GovCIO Media & Research"
-  },
-  {
-    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast (GovCIO Media & Research)",
-    "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
-    "newsDate": "January 25, 2022",
-    "newsSource": "GovCIO Media & Research"
-  },
-  {
-    "newsTitle": "A Cloud-Based Data Democratization Tool, RTI International",
-    "newsLink": "https://www.rti.org/impact/data-democratization-tool",
-    "newsDate": "March 15, 2023",
-    "newsSource": "RTI International"
-  },
-  {
-    "newsTitle": "Accelerating heart failure research, NHLBI NIH",
-    "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
-    "newsDate": "December 14, 2022",
-    "newsSource": "NHLBI NIH"
+    "newsSource": "HealthCast Podcast, GovCIO Media & Research"
   }
 ]

--- a/src/data/newsCoverage.json
+++ b/src/data/newsCoverage.json
@@ -1,0 +1,17 @@
+[
+  {
+    "newsTitle": "A Cloud-Based Data Democratization Tool, RTI International",
+    "newsLink": "https://www.rti.org/impact/data-democratization-tool",
+    "newsDate": "March 15, 2023"
+  },
+  {
+    "newsTitle": "Accelerating heart failure research, NHLBI NIH",
+    "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
+    "newsDate": "December 14, 2022"
+  },
+  {
+    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast (GovCIO Media & Research)",
+    "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
+    "newsDate": "January 25, 2022"
+  }
+]

--- a/src/data/newsCoverage.json
+++ b/src/data/newsCoverage.json
@@ -13,5 +13,20 @@
     "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast (GovCIO Media & Research)",
     "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
     "newsDate": "January 25, 2022"
+  },
+  {
+    "newsTitle": "Listen: The Open-Data Cloud Platform Transforming NIH Research, HealthCast (GovCIO Media & Research)",
+    "newsLink": "https://governmentciomedia.com/listen-open-data-cloud-platform-transforming-nih-research",
+    "newsDate": "January 25, 2022"
+  },
+  {
+    "newsTitle": "A Cloud-Based Data Democratization Tool, RTI International",
+    "newsLink": "https://www.rti.org/impact/data-democratization-tool",
+    "newsDate": "March 15, 2023"
+  },
+  {
+    "newsTitle": "Accelerating heart failure research, NHLBI NIH",
+    "newsLink": "https://www.nhlbi.nih.gov/news/2022/accelerating-heart-failure-research",
+    "newsDate": "December 14, 2022"
   }
 ]

--- a/src/pages/about/news.js
+++ b/src/pages/about/news.js
@@ -18,6 +18,7 @@ const NewsPage = () => (
       View recent news and media coverage for BDC.
     </Paragraph>
 
+    <Grid>
       <Row gutterWidth={ 32 } justify="center">
         {
           newsCoverage && newsCoverage.map((newsItem) => {
@@ -29,7 +30,7 @@ const NewsPage = () => (
           })
         }
       </Row>
-
+    </Grid>
   </PageContent>
 );
 

--- a/src/pages/about/news.js
+++ b/src/pages/about/news.js
@@ -1,42 +1,12 @@
 import React from "react";
+import styled from "styled-components";
 import { Link } from "../../components/link";
 import { PageContent } from "../../components/layout";
 import { Title, Paragraph } from "../../components/typography";
 import { SEO } from "../../components/seo";
-import { Card, CardHeader, CardBody } from "../../components/card";
+import { NewsCard, CardHeader, CardBody } from "../../components/card";
 import { Container as Grid, Row, Col } from "react-grid-system";
 import newsCoverage from '../../data/newsCoverage.json'
-
-
-const NewsCardComponent = ({newsItem}) => {
-  return (
-    <Card style={{
-      backgroundColor: "rgb(25, 48, 72)",
-      justifyContent: "space-between"
-
-    }}>
-      <CardHeader style={{
-      backgroundColor: "rgb(25, 48, 72)",
-      justifyContent: "start",
-        textAlign: "left",
-        marginTop: "2rem", 
-        lineHeight: "1.2", 
-        letterSpacing: "0.5px"
-      }}>
-        {newsItem.newsTitle}
-        </CardHeader>
-      <CardBody style={{
-      backgroundColor: "rgb(25, 48, 72)",
-      color: "white"
-    }}>
-        <Paragraph style={{letterSpacing: "1px"}}>
-        {newsItem.newsDate}
-        </Paragraph>
-      </CardBody>
-    </Card>
-  )
-}
-
 
 const NewsPage = () => (
   <PageContent width="95%" maxWidth="1200px" center gutters>
@@ -53,7 +23,9 @@ const NewsPage = () => (
         newsCoverage && newsCoverage.map((newsItem) => {
           return (
             <Col xs={ 12 } lg={ 4 } style={{ marginBottom: '32px' }}>
-              <NewsCardComponent newsItem={newsItem}/>
+              <Link to={newsItem.newsLink} noIcon>
+                <NewsCard newsItem={newsItem}/>
+              </Link>
             </Col>
           )
         })

--- a/src/pages/about/news.js
+++ b/src/pages/about/news.js
@@ -15,22 +15,20 @@ const NewsPage = () => (
     <Title>News Coverage</Title>
 
     <Paragraph>
-      Blurb about featured articles
+      View recent news and media coverage for BDC.
     </Paragraph>
 
-    <Row gutterWidth={ 32 } justify="center">
-      {
-        newsCoverage && newsCoverage.map((newsItem) => {
-          return (
-            <Col xs={ 12 } lg={ 4 } style={{ marginBottom: '32px' }}>
-              <Link to={newsItem.newsLink} noIcon>
-                <NewsCard newsItem={newsItem}/>
-              </Link>
-            </Col>
-          )
-        })
-      }
-    </Row>
+      <Row gutterWidth={ 32 } justify="center">
+        {
+          newsCoverage && newsCoverage.map((newsItem) => {
+            return (
+              <Col xs={ 12 } lg={ 4 } style={{ marginBottom: '32px' }}>
+                <NewsCard newsItem={newsItem} noIcon/>
+              </Col>
+            )
+          })
+        }
+      </Row>
 
   </PageContent>
 );

--- a/src/pages/about/news.js
+++ b/src/pages/about/news.js
@@ -1,0 +1,66 @@
+import React from "react";
+import { Link } from "../../components/link";
+import { PageContent } from "../../components/layout";
+import { Title, Paragraph } from "../../components/typography";
+import { SEO } from "../../components/seo";
+import { Card, CardHeader, CardBody } from "../../components/card";
+import { Container as Grid, Row, Col } from "react-grid-system";
+import newsCoverage from '../../data/newsCoverage.json'
+
+
+const NewsCardComponent = ({newsItem}) => {
+  return (
+    <Card style={{
+      backgroundColor: "rgb(25, 48, 72)",
+      justifyContent: "space-between"
+
+    }}>
+      <CardHeader style={{
+      backgroundColor: "rgb(25, 48, 72)",
+      justifyContent: "start",
+        textAlign: "left",
+        marginTop: "2rem", 
+        lineHeight: "1.2", 
+        letterSpacing: "0.5px"
+      }}>
+        {newsItem.newsTitle}
+        </CardHeader>
+      <CardBody style={{
+      backgroundColor: "rgb(25, 48, 72)",
+      color: "white"
+    }}>
+        <Paragraph style={{letterSpacing: "1px"}}>
+        {newsItem.newsDate}
+        </Paragraph>
+      </CardBody>
+    </Card>
+  )
+}
+
+
+const NewsPage = () => (
+  <PageContent width="95%" maxWidth="1200px" center gutters>
+    <SEO title="News Coverage" description="" keywords="" />
+
+    <Title>News Coverage</Title>
+
+    <Paragraph>
+      Blurb about featured articles
+    </Paragraph>
+
+    <Row gutterWidth={ 32 } justify="center">
+      {
+        newsCoverage && newsCoverage.map((newsItem) => {
+          return (
+            <Col xs={ 12 } lg={ 4 } style={{ marginBottom: '32px' }}>
+              <NewsCardComponent newsItem={newsItem}/>
+            </Col>
+          )
+        })
+      }
+    </Row>
+
+  </PageContent>
+);
+
+export default NewsPage;


### PR DESCRIPTION
This PR adds a news coverage page with three news items displayed as cards. The external link component has been modified to accommodate the card styles, and the external link icon functionality for this component is dependent on an "external" field in the content file. The content is stored as json in the `/src/data.newsCoverage.json` file.