### PR TITLE
Update news card

### DIFF
--- a/src/components/card/news-card.js
+++ b/src/components/card/news-card.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, CardHeader, CardBody } from ".";
+import { Card, CardHeader, CardBody } from "./";
 import { Heading, Paragraph } from "../../components/typography";
 import styled from "styled-components";
 import { ExternalLinkIcon } from "../icons";
@@ -9,9 +9,8 @@ import { Link } from "../../components/link"
 
 //make newscard warpper a styled Link?
 
-const NewsCardLink = styled(Link)`
+const NewsCardContainer = styled(Card)`
   overflow: hidden;
-  margin-bottom: 3rem;
   height: 100%;
   background: linear-gradient(180deg, var(--color-blueberry) 0%, #314f6e 100%);
   transition: transform 700ms;
@@ -24,56 +23,80 @@ const NewsCardLink = styled(Link)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 1.5rem 2rem;
+  padding: 1rem;
 `
 
 //add a filter on it to change the color
 
 const NewsCardHeading = styled.h2`
   line-height: 1.5; 
-  letter-spacing: 0.5px;
+  letter-spacing: 0.75px;
   text-decoration: none;
-  font-weight: 500;
-  font-size: 150%;
+  font-weight: 400;
+  font-size: 140%;
   color: #fff;
   &:hover, &:focus {
     text-decoration: none;
-  }
-
+  };
+  display: flex;
+  justify-content: flex-start;
 `
 
 
 export const NewsCard = ({ newsItem }) => {
+  const {
+    newsTitle, 
+    newsLink, 
+    newsDate, 
+    newsSource, 
+    external, 
+    paywall } = newsItem
+
   return (
-    <NewsCardLink to={newsItem.newsLink} noIcon>
+    <Link to={newsLink} noIcon>
+      <NewsCardContainer>
+        <div>
+          <NewsCardHeading>
+            {newsTitle}
+          </NewsCardHeading>
+          <Paragraph style={{letterSpacing: "1px", color: '#fff', fontSize: '1rem'}}>
+            {newsDate}
+          </Paragraph>
+        </div>
 
-      <div>
-        <NewsCardHeading >
-          {newsItem.newsTitle}
-        </NewsCardHeading>
-        <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
-          {newsItem.newsDate}
-        </Paragraph>
+        <div style={{display: "block"}}>
+          <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
+            {newsSource}
+          </Paragraph>
+          <div style={{display:'flex', flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'flex-end'}}>
+            {
+              paywall && (
+              <Paragraph style={{
+                letterSpacing: "0.5px", 
+                color: '#fff', 
+                fontSize: '0.7rem',
+                fontStyle: 'italic',
+                marginRight: '1rem',
+                marginBottom: 0}} >
+                *This article is located behind a paywall or site that requires log in.
+              </Paragraph>
+              )
+            }
+            { external &&
+              (
+                <div style={{textAlign: "right"}}>
+                  <ExternalLinkIcon
+                    fill={"#fff"}
+                    size={14}
+                    style={{ marginLeft: "0.25rem" }}
+                  />
+                </div>
+              )
+            }
 
-      </div>
-
-      <div style={{display: "block"}}>
-        <Paragraph style={{letterSpacing: "1px", color: '#fff'}}>
-          {newsItem.newsSource}
-        </Paragraph>
-        { newsItem.external &&
-          (
-            <div style={{textAlign: "right"}}>
-              <ExternalLinkIcon
-                fill={"#fff"}
-                size={14}
-                style={{ marginLeft: "0.25rem" }}
-              />
-            </div>
-          )
-        }
-      </div>
-
-    </NewsCardLink>
+          </div>
+        </div>
+      </NewsCardContainer>
+    </Link>
   );
 };

--- a/src/data/newsCoverage.json
+++ b/src/data/newsCoverage.json
@@ -1,5 +1,13 @@
 [
   {
+    "newsTitle": "NIH RECOVER Opens Long COVID Dataset To Researchers Via Database",
+    "newsLink": "https://insidehealthpolicy.com/daily-news/nih-recover-opens-long-covid-dataset-researchers-database",
+    "newsDate": "April 26, 2024",
+    "newsSource": "InsideHealthPolicy",
+    "external": true,
+    "paywall": true
+  },
+  {
     "newsTitle": "NIH eyes addition of imagery to Biomedical Platform",
     "newsLink": "https://executivegov.com/2024/04/nih-eyes-addition-of-imagery-other-data-types-to-researcher-cloud-platform",
     "newsDate": "April 1, 2024",

--- a/src/pages/about/news.js
+++ b/src/pages/about/news.js
@@ -18,8 +18,8 @@ const NewsPage = () => (
       View recent news and media coverage for BDC.
     </Paragraph>
 
-    <Grid >
-      <Row gutterWidth={ 32 } justify="start">
+    <Grid style={{maxWidth: '1200px'}}>
+      <Row gutterWidth={ 32 } justify="start" style={{ marginLeft: '-32px', marginRight: '-32px'}}>
         {
           newsCoverage && newsCoverage.map((newsItem) => {
             return (


### PR DESCRIPTION
This PR adds additional "paywall" field to the news items. If true, then a paywall notification will display inside the news item card.

I've also adjusted the spacing of the grid (made the grid full width instead of having extra space on the sides like before), made the card titles less bold and slightly smaller, and reduced the padding on the card content to improve the flow and balance of the page. Here's what the page should look like:

![screencapture-localhost-8000-about-news-2024-05-09-16_31_34](https://github.com/stagecc/bdc3-website-public/assets/74567117/d5409d2c-545e-4429-9b65-cbf537e495e6)